### PR TITLE
Await promises before returning them (keep stacktraces)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
     extends: [
         "@smartling/eslint-config-smartling"
-    ]
+    ],
+    "rules": {
+        "no-return-await": "off"
+    }
 };

--- a/api/auth/index.js
+++ b/api/auth/index.js
@@ -24,7 +24,7 @@ class SmartlingAuthApi extends SmartlingBaseApi {
     async authenticate() {
         this.resetRequestTimeStamp();
 
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/authenticate`,
             JSON.stringify({
@@ -38,7 +38,7 @@ class SmartlingAuthApi extends SmartlingBaseApi {
         if (this.tokenExists() && this.tokenCanBeRenewed()) {
             this.resetRequestTimeStamp();
 
-            return this.makeRequest(
+            return await this.makeRequest(
                 "post",
                 `${this.entrypoint}/authenticate/refresh`,
                 JSON.stringify({
@@ -47,7 +47,7 @@ class SmartlingAuthApi extends SmartlingBaseApi {
             );
         }
 
-        return this.authenticate();
+        return await this.authenticate();
     }
 
     resetRequestTimeStamp() {

--- a/api/base/index.js
+++ b/api/base/index.js
@@ -50,7 +50,7 @@ class SmartlingBaseApi {
     }
 
     async fetch(uri, options) {
-        return fetch(uri, options);
+        return await fetch(uri, options);
     }
 
     ua(clientId, clientVersion) {

--- a/api/file/index.js
+++ b/api/file/index.js
@@ -8,7 +8,7 @@ class SmartlingFileApi extends SmartlingBaseApi {
     }
 
     async getStatusForAllLocales(projectId, fileUri) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}/file/status`,
             { fileUri }
@@ -16,7 +16,7 @@ class SmartlingFileApi extends SmartlingBaseApi {
     }
 
     async getLastModified(projectId, fileUri) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}/file/last-modified`,
             { fileUri }
@@ -24,7 +24,7 @@ class SmartlingFileApi extends SmartlingBaseApi {
     }
 
     async downloadFile(projectId, fileUri, locale, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}/locales/${locale}/file`,
             Object.assign(params.export(), { fileUri }),

--- a/api/job-facade/index.js
+++ b/api/job-facade/index.js
@@ -45,7 +45,7 @@ class SmartlingJobFacadeApi extends SmartlingBaseApi {
     }
 
     async createBatch(projectId, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/${projectId}/batches`,
             JSON.stringify(params.export())
@@ -53,7 +53,7 @@ class SmartlingJobFacadeApi extends SmartlingBaseApi {
     }
 
     async uploadBatchFile(projectId, batchUid, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/${projectId}/batches/${batchUid}/file`,
             params.export()
@@ -61,7 +61,7 @@ class SmartlingJobFacadeApi extends SmartlingBaseApi {
     }
 
     async executeBatch(projectId, batchUid) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/${projectId}/batches/${batchUid}`,
             JSON.stringify({
@@ -71,7 +71,7 @@ class SmartlingJobFacadeApi extends SmartlingBaseApi {
     }
 
     async getBatchStatus(projectId, batchUid) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}/batches/${batchUid}`
         );

--- a/api/job/index.js
+++ b/api/job/index.js
@@ -8,7 +8,7 @@ class SmartlingJobApi extends SmartlingBaseApi {
     }
 
     async createJob(projectId, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/${projectId}/jobs`,
             JSON.stringify(params.export())
@@ -16,14 +16,14 @@ class SmartlingJobApi extends SmartlingBaseApi {
     }
 
     async getJob(projectId, translationJobUid) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}/jobs/${translationJobUid}`
         );
     }
 
     async getJobFiles(projectId, translationJobUid, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}/jobs/${translationJobUid}/files`,
             params.export()
@@ -31,7 +31,7 @@ class SmartlingJobApi extends SmartlingBaseApi {
     }
 
     async listJobs(projectId, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}/jobs`,
             params.export()

--- a/api/progress-tracker/index.js
+++ b/api/progress-tracker/index.js
@@ -8,7 +8,7 @@ class SmartlingProgressTrackerApi extends SmartlingBaseApi {
     }
 
     async createRecord(projectId, spaceId, objectId, data) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/projects/${projectId}/spaces/${spaceId}/objects/${objectId}/records`,
             JSON.stringify(data)
@@ -16,21 +16,21 @@ class SmartlingProgressTrackerApi extends SmartlingBaseApi {
     }
 
     async getRecord(projectId, spaceId, objectId, recordId) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/projects/${projectId}/spaces/${spaceId}/objects/${objectId}/records/${recordId}`
         );
     }
 
     async getRecords(projectId, spaceId, objectId) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/projects/${projectId}/spaces/${spaceId}/objects/${objectId}/records`
         );
     }
 
     async updateRecord(projectId, spaceId, objectId, recordId, data) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "put",
             `${this.entrypoint}/projects/${projectId}/spaces/${spaceId}/objects/${objectId}/records/${recordId}`,
             JSON.stringify(data)
@@ -38,21 +38,21 @@ class SmartlingProgressTrackerApi extends SmartlingBaseApi {
     }
 
     async deleteRecord(projectId, spaceId, objectId, recordId) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "delete",
             `${this.entrypoint}/projects/${projectId}/spaces/${spaceId}/objects/${objectId}/records/${recordId}`
         );
     }
 
     async deleteRecords(projectId, spaceId, objectId) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "delete",
             `${this.entrypoint}/projects/${projectId}/spaces/${spaceId}/objects/${objectId}`
         );
     }
 
     async getToken(accountUid) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/accounts/${accountUid}/token`
         );

--- a/api/project/index.js
+++ b/api/project/index.js
@@ -8,7 +8,7 @@ class SmartlingProjectApi extends SmartlingBaseApi {
     }
 
     async getProjectDetails(projectId) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}`
         );

--- a/api/strings/index.js
+++ b/api/strings/index.js
@@ -28,7 +28,7 @@ class SmartlingStringsApi extends SmartlingBaseApi {
     }
 
     async getStringsData(projectId, hashCodes) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/${projectId}/string-data`,
             JSON.stringify({

--- a/api/translation-requests/index.js
+++ b/api/translation-requests/index.js
@@ -8,7 +8,7 @@ class SmartlingTranslationRequestsApi extends SmartlingBaseApi {
     }
 
     async createTranslationRequest(projectId, bucketName, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/projects/${projectId}/buckets/${bucketName}/translation-requests`,
             JSON.stringify(params.export())
@@ -16,14 +16,14 @@ class SmartlingTranslationRequestsApi extends SmartlingBaseApi {
     }
 
     async getTranslationRequest(projectId, bucketName, translationRequestUid) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/projects/${projectId}/buckets/${bucketName}/translation-requests/${translationRequestUid}`
         );
     }
 
     async updateTranslationRequest(projectId, bucketName, translationRequestUid, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "put",
             `${this.entrypoint}/projects/${projectId}/buckets/${bucketName}/translation-requests/${translationRequestUid}`,
             JSON.stringify(params.export())
@@ -31,7 +31,7 @@ class SmartlingTranslationRequestsApi extends SmartlingBaseApi {
     }
 
     async searchTranslationRequests(projectId, bucketName, params) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/projects/${projectId}/buckets/${bucketName}/translation-requests`,
             params.export()

--- a/api/translation/index.js
+++ b/api/translation/index.js
@@ -26,7 +26,7 @@ class SmartlingTranslationApi extends SmartlingBaseApi {
     }
 
     async createTranslationPackage(projectId, translationJobUid, localeId, workflowStepUid) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/projects/${projectId}/locales/${localeId}/translation-packages`,
             JSON.stringify({
@@ -37,14 +37,14 @@ class SmartlingTranslationApi extends SmartlingBaseApi {
     }
 
     async getTranslationPackage(projectId, translationPackageUid) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/projects/${projectId}/translation-packages/${translationPackageUid}`
         );
     }
 
     async getTranslationPackageContent(projectId, translationPackageUid) {
-        return this.makeRequest(
+        return await this.makeRequest(
             "get",
             `${this.entrypoint}/projects/${projectId}/translation-packages/${translationPackageUid}/content`,
             null,
@@ -68,7 +68,7 @@ class SmartlingTranslationApi extends SmartlingBaseApi {
         // eslint-disable-next-line fp/no-delete
         delete headers["content-type"];
 
-        return this.makeRequest(
+        return await this.makeRequest(
             "post",
             `${this.entrypoint}/projects/${projectId}/locales/${localeId}/content`,
             form,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-sdk-nodejs",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Package for Smartling API",
   "main": "built/index.js",
   "scripts": {


### PR DESCRIPTION
1. We blindly follow `eslint` rules, particularly [this one](https://eslint.org/docs/rules/no-return-await):
```
You can avoid the extra microtask by not awaiting the return value, with the trade off of the function no longer being a part of the stack trace if an error is thrown asynchronously from the Promise being returned. This can make debugging more difficult.

When Not To Use It
...
If you want the functions to show up in stack traces (useful for debugging purposes)
```
2. This will not help in cases like:
```
network timeout at: <url> , stack=FetchError: network timeout at: <url>
    at Timeout.<anonymous> (/app/node_modules/node-fetch/lib/index.js:1448:13)
    at listOnTimeout (internal/timers.js:531:17)
    at processTimers (internal/timers.js:475:7)
```
because this promise rejection comes from `socket` **event** of request object (from `node-fetch` lib), and as I understand the error will only contain stacktrace of the context of event callback.