### PR TITLE
chore(package): tidy up build dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 built/
 coverage/
-false/
 node_modules/
 .nyc_output/
 test-results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 built/
 coverage/
+false/
 node_modules/
 .nyc_output/
 test-results.xml

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   },
   "homepage": "https://github.com/Smartling/api-sdk-nodejs#readme",
   "dependencies": {
-    "@types/mocha": "^9.0.0",
-    "@types/node": "^16.4.7",
     "cross-fetch": "^3.1.4",
     "default-user-agent": "^1.0.0",
     "form-data": "^4.0.0",
@@ -37,6 +35,8 @@
   },
   "devDependencies": {
     "@smartling/eslint-config-smartling": "^1.2.3",
+    "@types/mocha": "^9.0.0",
+    "@types/node": "^16.4.7",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
     "eslint": "^7.31.0",


### PR DESCRIPTION
This removes @types/mocha from being added to the production build

Ran into an issue with this on our build system when using @types/jest since they have competing global type definitions