### PR TITLE
added fieldValue to customField

### DIFF
--- a/api/jobs/dto/custom-field-dto.ts
+++ b/api/jobs/dto/custom-field-dto.ts
@@ -2,6 +2,7 @@ interface CustomFieldDto {
     fieldUid: string;
     fieldName: string;
     createdByUserUid: string;
+    fieldValue: string;
 }
 
 export { CustomFieldDto };


### PR DESCRIPTION
This addresses Issue #72.

According to the [api docs for getJobDetails](https://api-reference.smartling.com/#tag/Jobs/operation/getJobDetails) there should be a property on each customField in the response called `fieldValue`.
<img width="530" alt="Screen Shot 2022-08-30 at 3 24 39 PM" src="https://user-images.githubusercontent.com/97705773/187525545-4f211c9a-525b-478a-b303-65b0391088f1.png">


I've verified in my testing that it does come back from the api, but since the property is not part of the `CustomFieldDto` interface, typescript throws a compilation error.

This PR adds the property to the interface definition.