### PR TITLE
feature: add callback url to job params

### DIFF
--- a/api/files/index.ts
+++ b/api/files/index.ts
@@ -56,7 +56,7 @@ export class SmartlingFilesApi extends SmartlingBaseApi {
     ): Promise<string> {
         return await this.makeRequest(
             "get",
-            `${this.entrypoint}/${projectId}/locales/all/file`,
+            `${this.entrypoint}/${projectId}/locales/all/file/zip`,
             Object.assign(params.export(), { fileUri }),
             true
         );

--- a/api/files/params/download-file-all-translations-parameters.ts
+++ b/api/files/params/download-file-all-translations-parameters.ts
@@ -1,9 +1,3 @@
 import { DownloadFileParameters } from "./download-file-parameters";
 
-
-export class DownloadFileAllTranslationsParameters extends DownloadFileParameters {
-    setZipFileName(fileName: string): DownloadFileAllTranslationsParameters {
-        this.set("zipFileName", fileName);
-        return this;
-    }
-}
+export class DownloadFileAllTranslationsParameters extends DownloadFileParameters {}

--- a/api/job-batches/dto/batch-list-item-dto.ts
+++ b/api/job-batches/dto/batch-list-item-dto.ts
@@ -1,0 +1,14 @@
+import { BatchStatus } from "../params/batch-status";
+import { BatchDto } from "./batch-dto";
+
+interface BatchListItemDto extends BatchDto {
+    status: BatchStatus;
+    authorized: boolean;
+    translationJobUid: string;
+    projectId: string;
+    createdDate: Date
+    modifiedDate: Date
+
+}
+
+export { BatchListItemDto };

--- a/api/job-batches/index.ts
+++ b/api/job-batches/index.ts
@@ -10,6 +10,7 @@ import { CancelBatchFileParameters } from "./params/cancel-batch-file-parameters
 import { RegisterBatchFileParameters } from "./params/register-batch-file-parameters";
 import { BatchListItemDto } from "./dto/batch-list-item-dto";
 import { SmartlingListResponse } from "../http/smartling-list-response";
+import { ListBatchesParameters } from "./params/list-batches-parameters";
 
 export class SmartlingJobBatchesApi extends SmartlingBaseApi {
     constructor(smartlingApiBaseUrl: string, authApi: SmartlingAuthApi, logger: Logger) {
@@ -85,10 +86,13 @@ export class SmartlingJobBatchesApi extends SmartlingBaseApi {
         );
     }
 
-    async listBatches(projectId: string): Promise<SmartlingListResponse<BatchListItemDto>> {
+    async listBatches(projectId: string, params: ListBatchesParameters
+    ): Promise<SmartlingListResponse<BatchListItemDto>> {
         return await this.makeRequest(
             "get",
-            `${this.entrypoint}/${projectId}/batches`
+            `${this.entrypoint}/${projectId}/batches`,
+            params.export()
+
         );
     }
 }

--- a/api/job-batches/index.ts
+++ b/api/job-batches/index.ts
@@ -8,6 +8,8 @@ import { BatchStatusDto } from "./dto/batch-status-dto";
 import { BatchDto } from "./dto/batch-dto";
 import { CancelBatchFileParameters } from "./params/cancel-batch-file-parameters";
 import { RegisterBatchFileParameters } from "./params/register-batch-file-parameters";
+import { BatchListItemDto } from "./dto/batch-list-item-dto";
+import { SmartlingListResponse } from "../http/smartling-list-response";
 
 export class SmartlingJobBatchesApi extends SmartlingBaseApi {
     constructor(smartlingApiBaseUrl: string, authApi: SmartlingAuthApi, logger: Logger) {
@@ -80,6 +82,13 @@ export class SmartlingJobBatchesApi extends SmartlingBaseApi {
         return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}/batches/${batchUid}`
+        );
+    }
+
+    async listBatches(projectId: string): Promise<SmartlingListResponse<BatchListItemDto>> {
+        return await this.makeRequest(
+            "get",
+            `${this.entrypoint}/${projectId}/batches`
         );
     }
 }

--- a/api/job-batches/params/list-batches-parameters.ts
+++ b/api/job-batches/params/list-batches-parameters.ts
@@ -1,0 +1,41 @@
+import { BaseParameters } from "../../parameters/index";
+import { Order } from "../../parameters/order";
+import { BatchStatus } from "./batch-status";
+
+export class ListBatchesParameters extends BaseParameters {
+    setTranslationJobUid(uid: string): ListBatchesParameters {
+        this.set("translationJobUid", uid);
+
+        return this;
+    }
+
+    setLimit(limit: number): ListBatchesParameters {
+        if (limit > 0) {
+            this.set("limit", limit);
+        }
+
+        return this;
+    }
+
+    setOffset(offset: number): ListBatchesParameters {
+        if (offset >= 0) {
+            this.set("offset", offset);
+        }
+
+        return this;
+    }
+
+    setStatus(status: BatchStatus): ListBatchesParameters {
+        this.set("status", status);
+
+        return this;
+    }
+
+    setSort(field: "createdDate" | "status", order: Order): ListBatchesParameters {
+        this.set("sortBy", field);
+        this.set("sortDirection", order.toLowerCase());
+
+        return this;
+    }
+}
+

--- a/api/jobs/params/create-job-parameters.ts
+++ b/api/jobs/params/create-job-parameters.ts
@@ -37,4 +37,10 @@ export class CreateJobParameters extends BaseParameters {
 
         return this;
     }
+
+    setCallbackUrl(callbackUrl: string): CreateJobParameters {
+        this.set("callbackUrl", callbackUrl);
+
+        return this;
+    }
 }

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ export * from "./api/job-batches/dto/batch-dto";
 export * from "./api/job-batches/dto/batch-item-dto";
 export * from "./api/job-batches/dto/batch-locale-dto";
 export * from "./api/job-batches/dto/batch-status-dto";
+export * from "./api/job-batches/dto/batch-list-item-dto";
 export * from "./api/job-batches/params/create-batch-parameters";
 export * from "./api/job-batches/params/upload-batch-file-parameters";
 export * from "./api/job-batches/params/process-batch-action-parameters";

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,7 @@ export * from "./api/job-batches/params/cancel-batch-file-parameters";
 export * from "./api/job-batches/params/register-batch-file-parameters";
 export * from "./api/job-batches/params/batch-action";
 export * from "./api/job-batches/params/batch-status";
+export * from "./api/job-batches/params/list-batches-parameters";
 export * from "./api/job-batches/params/batch-item-status";
 export * from "./api/jobs/index";
 export * from "./api/jobs/dto/base-job-dto";

--- a/test/files.spec.ts
+++ b/test/files.spec.ts
@@ -202,7 +202,7 @@ describe("SmartlingFilesApi class tests.", () => {
                 sinon.assert.calledOnce(filesApiFetchStub);
                 sinon.assert.calledWithExactly(
                     filesApiFetchStub,
-                    `https://test.com/files-api/v2/projects/${projectId}/locales/all/file?retrievalType=published&debugMode=1&fileUri=testFileUri`,
+                    `https://test.com/files-api/v2/projects/${projectId}/locales/all/file/zip?retrievalType=published&debugMode=1&fileUri=testFileUri`,
                     {
                         headers: {
                             Authorization: "test_token_type test_access_token",
@@ -224,7 +224,7 @@ describe("SmartlingFilesApi class tests.", () => {
                 sinon.assert.calledOnce(filesApiFetchStub);
                 sinon.assert.calledWithExactly(
                     filesApiFetchStub,
-                    `https://test.com/files-api/v2/projects/${projectId}/locales/all/file?zipFileName=${zipFileName}&fileUri=testFileUri`,
+                    `https://test.com/files-api/v2/projects/${projectId}/locales/all/file/zip?zipFileName=${zipFileName}&fileUri=testFileUri`,
                     {
                         headers: {
                             Authorization: "test_token_type test_access_token",

--- a/test/files.spec.ts
+++ b/test/files.spec.ts
@@ -213,28 +213,6 @@ describe("SmartlingFilesApi class tests.", () => {
                     }
                 );
             });
-
-            it("Download file with zip's name set", async () => {
-                const zipFileName = "translations-2.zip";
-                params.setZipFileName(zipFileName);
-
-
-                await filesApi.downloadFileAllTranslations(projectId, fileUri, params);
-
-                sinon.assert.calledOnce(filesApiFetchStub);
-                sinon.assert.calledWithExactly(
-                    filesApiFetchStub,
-                    `https://test.com/files-api/v2/projects/${projectId}/locales/all/file/zip?zipFileName=${zipFileName}&fileUri=testFileUri`,
-                    {
-                        headers: {
-                            Authorization: "test_token_type test_access_token",
-                            "Content-Type": "application/json",
-                            "User-Agent": "test_user_agent"
-                        },
-                        method: "get"
-                    }
-                );
-            });
         });
 
         it("Delete file", async () => {

--- a/test/job-batches.spec.ts
+++ b/test/job-batches.spec.ts
@@ -229,5 +229,23 @@ describe("SmartlingJobBatchesAPI class tests.", () => {
                 }
             );
         });
+
+        it("List batches", async () => {
+            await jobBatchesApi.listBatches(projectId);
+
+            sinon.assert.calledOnce(jobBatchesApiFetchStub);
+            sinon.assert.calledWithExactly(
+                jobBatchesApiFetchStub,
+                `https://test.com/job-batches-api/v2/projects/${projectId}/batches`,
+                {
+                    headers: {
+                        Authorization: "test_token_type test_access_token",
+                        "Content-Type": "application/json",
+                        "User-Agent": "test_user_agent"
+                    },
+                    method: "get"
+                }
+            );
+        });
     });
 });

--- a/test/job-batches.spec.ts
+++ b/test/job-batches.spec.ts
@@ -10,6 +10,9 @@ import { FileType } from "../api/files/params/file-type";
 import { CancelBatchFileParameters } from "../api/job-batches/params/cancel-batch-file-parameters";
 import { RegisterBatchFileParameters } from "../api/job-batches/params/register-batch-file-parameters";
 import { streamToString } from "./stream-to-string";
+import { ListBatchesParameters } from "../api/job-batches/params/list-batches-parameters";
+import { Order } from "../api/parameters/order";
+import { BatchStatus } from "../api/job-batches/params/batch-status";
 
 describe("SmartlingJobBatchesAPI class tests.", () => {
     const projectId = "testProjectId";
@@ -231,19 +234,28 @@ describe("SmartlingJobBatchesAPI class tests.", () => {
         });
 
         it("List batches", async () => {
-            await jobBatchesApi.listBatches(projectId);
+            const params = new ListBatchesParameters();
+            const sortByParam = "status";
+            params
+                .setTranslationJobUid(jobUid)
+                .setLimit(100)
+                .setOffset(10)
+                .setStatus(BatchStatus.COMPLETED)
+                .setSort(sortByParam, Order.ASC);
+
+            await jobBatchesApi.listBatches(projectId, params);
 
             sinon.assert.calledOnce(jobBatchesApiFetchStub);
             sinon.assert.calledWithExactly(
                 jobBatchesApiFetchStub,
-                `https://test.com/job-batches-api/v2/projects/${projectId}/batches`,
+                `https://test.com/job-batches-api/v2/projects/${projectId}/batches?translationJobUid=${jobUid}&limit=100&offset=10&status=${BatchStatus.COMPLETED}&sortBy=${sortByParam}&sortDirection=${(Order.ASC).toLowerCase()}`,
                 {
+                    method: "get",
                     headers: {
                         Authorization: "test_token_type test_access_token",
                         "Content-Type": "application/json",
                         "User-Agent": "test_user_agent"
-                    },
-                    method: "get"
+                    }
                 }
             );
         });

--- a/test/jobs.spec.ts
+++ b/test/jobs.spec.ts
@@ -52,7 +52,8 @@ describe("SmartlingJobsAPI class tests.", () => {
                 .setName("Test job")
                 .setDescription("Test job description")
                 .setDueDate(new Date("2100-12-31T22:00:00.000Z"))
-                .setTargetLocaleIds(["pt-PT"]);
+                .setTargetLocaleIds(["pt-PT"])
+                .setCallbackUrl("testCallbackUrl");
 
 
             await jobApi.createJob(projectId, params);
@@ -62,7 +63,7 @@ describe("SmartlingJobsAPI class tests.", () => {
                 jobServiceApiFetchStub,
                 `https://test.com/jobs-api/v3/projects/${projectId}/jobs`,
                 {
-                    body: "{\"jobName\":\"Test job\",\"description\":\"Test job description\",\"dueDate\":\"2100-12-31T22:00:00.000Z\",\"targetLocaleIds\":[\"pt-PT\"]}",
+                    body: "{\"jobName\":\"Test job\",\"description\":\"Test job description\",\"dueDate\":\"2100-12-31T22:00:00.000Z\",\"targetLocaleIds\":[\"pt-PT\"],\"callbackUrl\":\"testCallbackUrl\"}",
                     headers: {
                         Authorization: "test_token_type test_access_token",
                         "Content-Type": "application/json",


### PR DESCRIPTION
@PavelLoparev regarding commit #2 (change endpoint to download all files translations): Even after the fix, I did not manage to write a `.zip` to my filesystem although I did not dig much into the code. Is writing non-raw responses supported atm? If not, do you have any plan of working on it in the near future?

For now, I consider it out of this MR's scope (no time) and will fetch translations separately by locales.

Let me know, thanks!