### PR TITLE
CON-1508: Decorator based arguments validation approach

### DIFF
--- a/api/decorators/index.ts
+++ b/api/decorators/index.ts
@@ -1,0 +1,46 @@
+export function IsNotEmpty(
+    target: any,
+    methodName: string,
+    parameterIndex: number
+) {
+    if (!target?.validations) {
+        target.validations = [];
+    }
+
+    target.validations.push(`${methodName}:${parameterIndex}:${IsNotEmpty.name}`);
+}
+
+function IsNotEmptyValidate(
+    methodName: string,
+    argumentIndex: number,
+    argumentValue: any
+) {
+    if (argumentValue === '' || argumentValue === null || argumentValue === undefined) {
+        throw new Error(`Invalid empty argument at index ${argumentIndex} with "${argumentValue}" value in "${methodName}" method`);
+    }
+}
+
+export function Validate(target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) {
+    let method = descriptor.value!;
+
+    descriptor.value = function (...args: Array<any>) {
+        if (target?.validations?.length) {
+            for (const validation of target.validations) {
+                const [methodName, argumentIndex, validatorName] = validation.split(":");
+
+                if (method.name === methodName) {
+                    switch (validatorName) {
+                        case IsNotEmpty.name:
+                            const argumentValue = args[argumentIndex];
+
+                            IsNotEmptyValidate(methodName, argumentIndex, argumentValue);
+
+                            break;
+                    }
+                }
+            }
+        }
+
+        return method.apply(this, arguments);
+    };
+}

--- a/api/projects/index.ts
+++ b/api/projects/index.ts
@@ -2,6 +2,7 @@ import { SmartlingBaseApi } from "../base/index";
 import { SmartlingAuthApi } from "../auth/index";
 import { Logger } from "../logger";
 import { ProjectDto } from "./dto/project-dto";
+import { IsNotEmpty, Validate } from "../decorators";
 
 export class SmartlingProjectsApi extends SmartlingBaseApi {
     constructor(smartlingApiBaseUrl: string, authApi: SmartlingAuthApi, logger: Logger) {
@@ -10,7 +11,8 @@ export class SmartlingProjectsApi extends SmartlingBaseApi {
         this.entrypoint = `${smartlingApiBaseUrl}/projects-api/v2/projects`;
     }
 
-    async getProjectDetails(projectId: string): Promise<ProjectDto> {
+    @Validate
+    async getProjectDetails(@IsNotEmpty projectId: string): Promise<ProjectDto> {
         return await this.makeRequest(
             "get",
             `${this.entrypoint}/${projectId}`

--- a/index.ts
+++ b/index.ts
@@ -103,3 +103,4 @@ export * from "./api/locales/dto/direction";
 export * from "./api/locales/dto/word-delimeter";
 export * from "./api/locales/params/get-locales-parameters";
 export * from "./api/locales/index";
+export * from "./api/decorators/index";

--- a/test/projects.spec.ts
+++ b/test/projects.spec.ts
@@ -2,6 +2,7 @@ import sinon from "sinon";
 import { SmartlingProjectsApi } from "../api/projects/index";
 import { loggerMock, authMock, responseMock } from "./mock";
 import { SmartlingAuthApi } from "../api/auth/index";
+import assert from "assert";
 
 describe("SmartlingProjectsApi class tests.", () => {
     const projectId = "testProjectId";
@@ -46,6 +47,26 @@ describe("SmartlingProjectsApi class tests.", () => {
                     method: "get"
                 }
             );
+        });
+
+        describe("IsNotEmpty decorator test", () => {
+            it("Empty string", async () => {
+                await assert.rejects(async () => {
+                    await projectsApi.getProjectDetails("")
+                }, new Error('Invalid empty argument at index 0 with "" value in "getProjectDetails" method'));
+            });
+
+            it("null string", async () => {
+                await assert.rejects(async () => {
+                    await projectsApi.getProjectDetails(null)
+                }, new Error('Invalid empty argument at index 0 with "null" value in "getProjectDetails" method'));
+            });
+
+            it("undefined string", async () => {
+                await assert.rejects(async () => {
+                    await projectsApi.getProjectDetails(undefined)
+                }, new Error('Invalid empty argument at index 0 with "undefined" value in "getProjectDetails" method'));
+            });
         });
     });
 });


### PR DESCRIPTION
Arguments decorator-based validation approach:
1. `IsNotEmpty` argument decorator "registers" validation in the target object (just an array of strings like `<methodName>:<parameterIndex>:<validatorName>`)
2. `Validation` method decorator reads all registered validations and executes them.

This scheme with 2 decorators instead of just one argument decorator is only needed because argument level decorator can't access actual argument value (it's weird)

[Usage example](https://github.com/typestack/class-validator/pull/2432/files#diff-6fb3fad5d6b9abb19c4fb3b89fd51c25d4b2368b69f94f65286c92f8949e54f8R1-R20):
```
export class MyClass {
    @Validate
    async myMethod(@IsNotEmpty test: string): Promise<void> {
        ...
    }
}
```

As I get it [I can't use](https://github.com/typestack/class-validator/issues/115) `class-validator` lib because it's only for class property validations, not method arguments.