### PR TITLE
download zip encoding issue fix

### DIFF
--- a/api/base/index.ts
+++ b/api/base/index.ts
@@ -135,7 +135,7 @@ export class SmartlingBaseApi {
 
         // Special case for file download - return raw response text.
         if (returnRawResponseBody) {
-            return response.text();
+            return response.arrayBuffer();
         }
 
         try {

--- a/api/base/index.ts
+++ b/api/base/index.ts
@@ -89,7 +89,7 @@ export class SmartlingBaseApi {
         verb: string,
         uri: string,
         payload: Record<string, unknown> | string | FormData = null,
-        returnRawResponseBody = false,
+        returnRawResponseBody: false | true | 'buffer' = false,
         headers: Record<string, unknown> = {}
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     ): Promise<any> {
@@ -134,8 +134,11 @@ export class SmartlingBaseApi {
         }
 
         // Special case for file download - return raw response text.
-        if (returnRawResponseBody) {
+        if (returnRawResponseBody === 'buffer') {
             return response.arrayBuffer();
+        }
+        if (returnRawResponseBody) {
+            return response.text();
         }
 
         try {

--- a/api/file-translations/index.ts
+++ b/api/file-translations/index.ts
@@ -74,7 +74,7 @@ export class SmartlingFileTranslationsApi extends SmartlingBaseApi {
             "get",
             `${this.entrypoint}/${accountUid}/files/${fileUid}/mt/${mtUid}/locales/all/file/zip`,
             null,
-            true
+            'buffer'
         );
     }
 

--- a/api/files/index.ts
+++ b/api/files/index.ts
@@ -59,7 +59,7 @@ export class SmartlingFilesApi extends SmartlingBaseApi {
             "get",
             `${this.entrypoint}/${projectId}/locales/all/file/zip`,
             Object.assign(params.export(), { fileUri }),
-            true
+            'buffer'
         );
     }
 


### PR DESCRIPTION
I ran into an issue with `downloadFileAllTranslations`. The library returns `response.text()` which decodes the body in a lossy way that corrupts the zip file and prevents us from being able to use it. We instead need to pass a buffer back so I've extended the `makeRequest` call to be able to do this.