### PR TITLE
Download zip files methods return array buffer

### DIFF
--- a/api/base/enum/response-body-type.ts
+++ b/api/base/enum/response-body-type.ts
@@ -1,0 +1,4 @@
+export enum ResponseBodyType {
+    TEXT = "TEXT",
+    ARRAY_BUFFER = "ARRAY_BUFFER",
+}

--- a/api/base/index.ts
+++ b/api/base/index.ts
@@ -6,6 +6,7 @@ import { ParsedUrlQueryInput, stringify } from "querystring";
 import { Logger } from "../logger";
 import { SmartlingException } from "../exception/index";
 import { SmartlingAuthApi } from "../auth/index";
+import { ResponseBodyType } from "./enum/response-body-type";
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const packageJson = require("../../package.json");
@@ -89,7 +90,7 @@ export class SmartlingBaseApi {
         verb: string,
         uri: string,
         payload: Record<string, unknown> | string | FormData = null,
-        returnRawResponseBody = false,
+        returnRawResponseBody: ResponseBodyType | boolean = false,
         headers: Record<string, unknown> = {}
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     ): Promise<any> {
@@ -134,8 +135,13 @@ export class SmartlingBaseApi {
         }
 
         // Special case for file download - return raw response text.
-        if (returnRawResponseBody) {
+        if (returnRawResponseBody === true || returnRawResponseBody === ResponseBodyType.TEXT) {
             return response.text();
+        }
+
+        // Special case for zip file download - return raw response array buffer.
+        if (returnRawResponseBody === ResponseBodyType.ARRAY_BUFFER) {
+            return response.arrayBuffer();
         }
 
         try {

--- a/api/file-translations/index.ts
+++ b/api/file-translations/index.ts
@@ -9,6 +9,7 @@ import { TranslateFileParameters } from "./params/translate-file-parameters";
 import { TranslationStatusDto } from "./dto/translation-status-dto";
 import { LanguageDetectionDto } from "./dto/language-detection-dto";
 import { LanguageDetectionStatusDto } from "./dto/language-detection-status-dto";
+import { ResponseBodyType } from "../base/enum/response-body-type";
 
 export class SmartlingFileTranslationsApi extends SmartlingBaseApi {
     constructor(smartlingApiBaseUrl: string, authApi: SmartlingAuthApi, logger: Logger) {
@@ -74,7 +75,7 @@ export class SmartlingFileTranslationsApi extends SmartlingBaseApi {
             "get",
             `${this.entrypoint}/${accountUid}/files/${fileUid}/mt/${mtUid}/locales/all/file/zip`,
             null,
-            true
+            ResponseBodyType.ARRAY_BUFFER
         );
     }
 

--- a/api/files/index.ts
+++ b/api/files/index.ts
@@ -11,6 +11,7 @@ import { UploadedFileDto } from "./dto/uploaded-file-dto";
 import { FileStatusForProjectDto } from "./dto/file-status-for-project-dto";
 import { DownloadFileAllTranslationsParameters } from "./params/download-file-all-translations-parameters";
 import { RecentlyUploadedFilesParameters } from "./params/recently-uploaded-files";
+import { ResponseBodyType } from "../base/enum/response-body-type";
 
 export class SmartlingFilesApi extends SmartlingBaseApi {
     constructor(smartlingApiBaseUrl: string, authApi: SmartlingAuthApi, logger: Logger) {
@@ -59,7 +60,7 @@ export class SmartlingFilesApi extends SmartlingBaseApi {
             "get",
             `${this.entrypoint}/${projectId}/locales/all/file/zip`,
             Object.assign(params.export(), { fileUri }),
-            true
+            ResponseBodyType.ARRAY_BUFFER
         );
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "smartling-api-sdk-nodejs",
-  "version": "2.13.1",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smartling-api-sdk-nodejs",
-      "version": "2.13.1",
+      "version": "2.15.0",
       "license": "ISC",
       "dependencies": {
+        "@types/mocha": "^9.0.0",
         "@types/node": "^16.4.7",
         "cross-fetch": "^3.1.4",
         "default-user-agent": "^1.0.0",
@@ -19,7 +20,6 @@
         "typescript": "^4.3.5"
       },
       "devDependencies": {
-        "@types/mocha": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
         "ansi-regex": "^5.0.1",
@@ -1085,8 +1085,7 @@
     "node_modules/@types/mocha": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
-      "dev": true
+      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg=="
     },
     "node_modules/@types/node": {
       "version": "16.11.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartling-api-sdk-nodejs",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "Package for Smartling API",
   "main": "built/index.js",
   "engines": {

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -18,5 +18,6 @@ export const responseMock = {
     status: 200,
     text: async (): Promise<string> => "{}",
     json: async (): Promise<void> => {},
+    arrayBuffer: async (): Promise<ArrayBuffer> => new ArrayBuffer(1),
     headers: {}
 };


### PR DESCRIPTION
Closes https://github.com/Smartling/api-sdk-nodejs/pull/115

Valid zip file can be saved like this:
```
fs.writeFileSync(
    "test.zip",
    Buffer.from(
        await apiClient.downloadFileAllTranslations(
            "<projected>",
            "<fileUri>",
            new DownloadFileParameters().setRetrievalType(RetrievalType.PUBLISHED)
        )
    )
);
```